### PR TITLE
fix: non-indexed table dropdown url

### DIFF
--- a/components/Table/TableNonIndexedUrls.vue
+++ b/components/Table/TableNonIndexedUrls.vue
@@ -357,7 +357,7 @@ const filters = [
       </div>
     </template>
     <template #actions-data="{ row }">
-      <UDropdown :items="[[{ label: 'Open URL', click: () => openUrl(row.url, '_blank'), icon: 'i-heroicons-arrow-up-right' }]]">
+      <UDropdown :items="[[{ label: 'Open URL', click: () => openUrl(joinURL(`https://${siteUrlFriendly}`, row.url), '_blank'), icon: 'i-heroicons-arrow-up-right' }]]">
         <UButton variant="link" icon="i-heroicons-ellipsis-vertical" color="gray" />
       </UDropdown>
     </template>


### PR DESCRIPTION
<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
This PR is solving a redirect bug in dashboard.

Reproduce: 
- Go to dashboard of any website
- Make sure you have a non-indexed page in table.
- Toggle a page's dropdown (by clicking three ellipsis at the end of row)
- Click "Open URL"
- Link is redirecting you to `https://requestindexing.com` + the page you clicked.
### Linked Issues
https://github.com/harlan-zw/request-indexing/issues/8

### Additional context
It's my first PR. Please tell me if anything wrong. Thank you!
<!-- e.g. is there anything you'd like reviewers to focus on? -->
