### PR TITLE
Handle undefined OAuth token pools gracefully

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .output
 .data
 ../.nuxt
+.nuxt
 .nitro
 .cache
 dist

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -2,8 +2,8 @@ import { env } from 'std-env'
 import { hash } from 'ohash'
 import type { OAuthPoolToken } from '~/types'
 
-let tokens: Partial<OAuthPoolToken>[] = env.NUXT_OAUTH_POOL ? JSON.parse(env.NUXT_OAUTH_POOL) : false
-const privateTokens: Partial<OAuthPoolToken>[] = env.NUXT_OAUTH_PRIVATE_POOL ? JSON.parse(env.NUXT_OAUTH_PRIVATE_POOL) : false
+let tokens: Partial<OAuthPoolToken>[] = env.NUXT_OAUTH_POOL ? JSON.parse(env.NUXT_OAUTH_POOL) : []
+const privateTokens: Partial<OAuthPoolToken>[] = env.NUXT_OAUTH_PRIVATE_POOL ? JSON.parse(env.NUXT_OAUTH_PRIVATE_POOL) : []
 
 export default defineNuxtConfig({
   extends: ['@nuxt/ui-pro'],
@@ -18,7 +18,7 @@ export default defineNuxtConfig({
     '@nuxtjs/seo',
     (_, nuxt) => {
       // seed the main tokens if there isn't a pool available
-      if (!tokens) {
+      if (tokens.length === 0) {
         tokens = [{
           label: 'primary',
           client_id: env.NUXT_OAUTH_GOOGLE_CLIENT_ID!,
@@ -29,9 +29,9 @@ export default defineNuxtConfig({
       nuxt.options.nitro.virtual['#app/token-pool.mjs']
         = [
           `export const tokens = ${JSON.stringify(tokens.map((t) => {
-        t.id = t.id || hash(t)
-        return t
-      }))}`,
+            t.id = t.id || hash(t)
+            return t
+          }))}`,
           `export const privateTokens = ${JSON.stringify(privateTokens.map((t) => {
             t.id = t.id || hash(t)
             return t


### PR DESCRIPTION
Hi @harlan-zw,
<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

**What did I change?**
- Modified the initialization of tokens and privateTokens in nuxt.config.ts - Now initializing as empty arrays ([]) instead of false when environment variables are not set.
- Updated the condition for seeding main tokens - Now checks if the tokens array is empty (tokens.length === 0) instead of checking if it's falsy.
- Left the rest of the Nuxt configuration unchanged.

**Why did I change it?**
- To fix a runtime error: "privateTokens.map is not a function - This error occurred because privateTokens was sometimes false instead of an array.
- To improve the robustness of the OAuth token handling: The code now gracefully handles cases where the OAuth pool environment variables are not set.
- To ensure consistent behavior: By always working with arrays (even if empty), we prevent type-related errors and make the code more predictable.
- To maintain functionality when environment variables are not set: The changes allow the application to run without errors, even if the OAuth pools are not configured, potentially falling back to default behavior.

### Linked Issues

- #17 
